### PR TITLE
操作符 API 翻译：elementAt -> mapTo

### DIFF
--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -38,8 +38,8 @@ import { TeardownLogic } from '../Subscription';
  *
  * @param {number} index 是 Subscription 开始后的第i个通知的索引数值，该值是从 `0` 开始。
  * @param {T} [defaultValue] 缺失索引时返回的默认值。
- * @return {Observable} Observable 发出单个项，如果能找到这项的话。找不到时，如果有给定
- * 的默认值，则发出默认值，没有则发出错误。
+ * @return {Observable} 如果能找到这个项的话，那么该 Observable 发出此单个项。找不到时，如果有给定
+ * 的默认值，则发出默认值，否则发出错误。
  * @method elementAt
  * @owner Observable
  */

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -5,28 +5,26 @@ import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 
 /**
- * Emits the single value at the specified `index` in a sequence of emissions
- * from the source Observable.
+ * 只发出单个值，这个值位于源 Observable 的发送序列中的指定 `index` 处。
  *
- * <span class="informal">Emits only the i-th value, then completes.</span>
+ * <span class="informal">只发出第i个值, 然后完成。</span>
  *
  * <img src="./img/elementAt.png" width="100%">
+ * 
+ * `elementAt` 返回的 Observable 会发出源 Observable 指定 `index` 处的项，如果
+ * `index` 超出范围并且提供了 `default` 参数的话，会发出一个默认值。如果没有提供
+ * `default` 参数并且 `index` 超出范围，那么输出 Observable 会发出一个 
+ * `ArgumentOutOfRangeError` 错误。
  *
- * `elementAt` returns an Observable that emits the item at the specified
- * `index` in the source Observable, or a default value if that `index` is out
- * of range and the `default` argument is provided. If the `default` argument is
- * not given and the `index` is out of range, the output Observable will emit an
- * `ArgumentOutOfRangeError` error.
- *
- * @example <caption>Emit only the third click event</caption>
+ * @example <caption>只发出第三次的点击事件</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.elementAt(2);
  * result.subscribe(x => console.log(x));
  *
- * // Results in:
+ * // 结果：
  * // click 1 = nothing
  * // click 2 = nothing
- * // click 3 = MouseEvent object logged to console
+ * // click 3 = 打印到控制台的 MouseEvent 对象
  *
  * @see {@link first}
  * @see {@link last}
@@ -34,15 +32,14 @@ import { TeardownLogic } from '../Subscription';
  * @see {@link single}
  * @see {@link take}
  *
- * @throws {ArgumentOutOfRangeError} When using `elementAt(i)`, it delivers an
- * ArgumentOutOrRangeError to the Observer's `error` callback if `i < 0` or the
- * Observable has completed before emitting the i-th `next` notification.
+ * @throws {ArgumentOutOfRangeError} 当使用 `elementAt(i)` 时，如果 `i < 0` 或
+ * 在发送第i个 `next` 通知前 Observable 已经完成了，它会发送 ArgumentOutOrRangeError 
+ * 给观察者的 `error` 回调函数。
  *
- * @param {number} index Is the number `i` for the i-th source emission that has
- * happened since the subscription, starting from the number `0`.
- * @param {T} [defaultValue] The default value returned for missing indices.
- * @return {Observable} An Observable that emits a single item, if it is found.
- * Otherwise, will emit the default value if given. If not, then emits an error.
+ * @param {number} index 是 Subscription 开始后的第i个通知的索引数值，该值是从 `0` 开始。
+ * @param {T} [defaultValue] 缺失索引时返回的默认值。
+ * @return {Observable} Observable 发出单个项，如果能找到这项的话。找不到时，如果有给定
+ * 的默认值，则发出默认值，没有则发出错误。
  * @method elementAt
  * @owner Observable
  */

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -4,16 +4,16 @@ import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 
 /**
- * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.
+ * 返回的 Observable 发出是否源 Observable 的每项都满足指定的条件。
  *
- * @example <caption>A simple example emitting true if all elements are less than 5, false otherwise</caption>
+ * @example <caption>一个简单示例：如果所有元素都小于5就发出 `true`，反之 `false`</caption>
  *  Observable.of(1, 2, 3, 4, 5, 6)
  *     .every(x => x < 5)
  *     .subscribe(x => console.log(x)); // -> false
  *
- * @param {function} predicate A function for determining if an item meets a specified condition.
- * @param {any} [thisArg] Optional object to use for `this` in the callback.
- * @return {Observable} An Observable of booleans that determines if all items of the source Observable meet the condition specified.
+ * @param {function} predicate 用来确定每一项是否满足指定条件的函数。
+ * @param {any} [thisArg] 可选对象，作为回调函数中的 `this` 使用。
+ * @return {Observable} 布尔值的 Observable，用来确定是否源 Observable 的所有项都满足指定条件。
  * @method every
  * @owner Observable
  */

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -6,25 +6,23 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 /**
- * Converts a higher-order Observable into a first-order Observable by dropping
- * inner Observables while the previous inner Observable has not yet completed.
+ * 当前一个内部 Observable 还未完成的情况下，通过丢弃内部 Observable 使得
+ * 高阶 Observable 转换成一阶 Observable。
  *
- * <span class="informal">Flattens an Observable-of-Observables by dropping the
- * next inner Observables while the current inner is still executing.</span>
+ * <span class="informal">在当前内部 Observable 仍在执行的情况下，通过丢弃
+ * 内部 Observable 将高阶 Observable 打平。</span>
  *
  * <img src="./img/exhaust.png" width="100%">
  *
- * `exhaust` subscribes to an Observable that emits Observables, also known as a
- * higher-order Observable. Each time it observes one of these emitted inner
- * Observables, the output Observable begins emitting the items emitted by that
- * inner Observable. So far, it behaves like {@link mergeAll}. However,
- * `exhaust` ignores every new inner Observable if the previous Observable has
- * not yet completed. Once that one completes, it will accept and flatten the
- * next inner Observable and repeat this process.
+ * `exhaust` 订阅发出 Observables 的 Observable，也就是高阶 Observable 。
+ * 每次观察到这些已发出的内部 Observables 中的其中一个时，输出 Observable 开始发出该内部 Observable 
+ * 要发出的项。到目前为止，它的行为就像 {@link mergeAll} 。然而，如果前一个 Observable 
+ * 还未完成的话，`exhaust` 会忽略每个新的内部 Observable 。一旦完成，它将接受并打平下一个
+ * 内部 Observable ，然后重复此过程。
  *
- * @example <caption>Run a finite timer for each click, only if there is no currently active timer</caption>
+ * @example <caption>只要没有当前活动的计时器，那么每次点击就会运行一个有限的计时器。</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000));
+ * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000).take(5));
  * var result = higherOrder.exhaust();
  * result.subscribe(x => console.log(x));
  *
@@ -35,8 +33,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * @see {@link exhaustMap}
  * @see {@link zipAll}
  *
- * @return {Observable} An Observable that takes a source of Observables and propagates the first observable
- * exclusively until it completes before subscribing to the next.
+ * @return {Observable} Observable 接收源 Observable 并只专注于传播第一个 Observable 直到它完成，然后订阅下一个 Observable 。
  * @method exhaust
  * @owner Observable
  */

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -10,7 +10,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * 高阶 Observable 转换成一阶 Observable。
  *
  * <span class="informal">在当前内部 Observable 仍在执行的情况下，通过丢弃
- * 内部 Observable 将高阶 Observable 打平。</span>
+ * 接下来的内部 Observable 将高阶 Observable 打平。</span>
  *
  * <img src="./img/exhaust.png" width="100%">
  *

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -12,26 +12,23 @@ export function exhaustMap<T, I, R>(this: Observable<T>, project: (value: T, ind
 /* tslint:enable:max-line-length */
 
 /**
- * Projects each source value to an Observable which is merged in the output
- * Observable only if the previous projected Observable has completed.
+ * 将每个源值投射成 Observable，只有当前一个投射的 Observable 已经完成的话，
+ * 这个 Observable 才会被合并到输出 Observable 中。
  *
- * <span class="informal">Maps each value to an Observable, then flattens all of
- * these inner Observables using {@link exhaust}.</span>
+ * <span class="informal">把每个值映射成 Observable，然后使用 {@link exhaust} 
+ * 操作符打平所有的内部 Observables 。</span>
  *
  * <img src="./img/exhaustMap.png" width="100%">
  *
- * Returns an Observable that emits items based on applying a function that you
- * supply to each item emitted by the source Observable, where that function
- * returns an (so-called "inner") Observable. When it projects a source value to
- * an Observable, the output Observable begins emitting the items emitted by
- * that projected Observable. However, `exhaustMap` ignores every new projected
- * Observable if the previous projected Observable has not yet completed. Once
- * that one completes, it will accept and flatten the next projected Observable
- * and repeat this process.
+ * 返回的 Observable 基于应用一个函数来发送项，该函数提供给源 Observable 发出的每个项，
+ * 并返回一个(所谓的“内部”) Observable 。当它将源值投射成 Observable 时，输出 Observable 
+ * 开始发出由投射的 Observable 发出的项。然而，如果前一个投射的 Observable 还未完成的话，
+ * 那么 `exhaustMap` 会忽略每个新投射的 Observable 。一旦完成，它将接受并打平下一个
+ * 内部 Observable ，然后重复此过程。
  *
- * @example <caption>Run a finite timer for each click, only if there is no currently active timer</caption>
+ * @example <caption>只要没有当前活动的计时器，那么每次点击就会运行一个有限的计时器。</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.exhaustMap((ev) => Rx.Observable.interval(1000));
+ * var result = clicks.exhaustMap((ev) => Rx.Observable.interval(1000).take(5));
  * result.subscribe(x => console.log(x));
  *
  * @see {@link concatMap}
@@ -39,20 +36,17 @@ export function exhaustMap<T, I, R>(this: Observable<T>, project: (value: T, ind
  * @see {@link mergeMap}
  * @see {@link switchMap}
  *
- * @param {function(value: T, ?index: number): ObservableInput} project A function
- * that, when applied to an item emitted by the source Observable, returns an
- * Observable.
+ * @param {function(value: T, ?index: number): ObservableInput} project 函数，
+ * 当应用于源 Observable 发出的项时，返回一个 Observable 。
  * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
- * @return {Observable} An Observable containing projected Observables
- * of each item of the source, ignoring projected Observables that start before
- * their preceding Observable has completed.
+ * 函数，它用于产生基于值的输出 Observable 和源(外部)发送和内部 Observable 发送的索引。
+ * 传递给这个函数参数有：
+ * - `outerValue`: 来自源的值
+ * - `innerValue`: 来自投射的 Observable 的值
+ * - `outerIndex`: 来自源的值的 "index"
+ * - `innerIndex`: 来自投射的 Observable 的值的 "index"
+ * @return {Observable} 这个 Observable 包含源中每项的投射 Observable，
+ * 忽略在前一个 Observable 完成之前就已经开始的 Observable。
  * @method exhaustMap
  * @owner Observable
  */

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -12,7 +12,7 @@ export function exhaustMap<T, I, R>(this: Observable<T>, project: (value: T, ind
 /* tslint:enable:max-line-length */
 
 /**
- * 将每个源值投射成 Observable，只有当前一个投射的 Observable 已经完成的话，
+ * 将每个源值投射成 Observable，只有当前一个投射的 Observable 已经完成，
  * 这个 Observable 才会被合并到输出 Observable 中。
  *
  * <span class="informal">把每个值映射成 Observable，然后使用 {@link exhaust} 

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -15,26 +15,20 @@ export function expand<T, R>(this: Observable<T>, project: (value: T, index: num
 /* tslint:enable:max-line-length */
 
 /**
- * Recursively projects each source value to an Observable which is merged in
- * the output Observable.
+ * 递归地将每个源值投射成 Observable，这个 Observable 会被合并到输出 Observable 中。
  *
- * <span class="informal">It's similar to {@link mergeMap}, but applies the
- * projection function to every source value as well as every output value.
- * It's recursive.</span>
+ * <span class="informal">它与 {@link mergeMap} 类似，但将投射函数应用于每个源值
+ * 以及每个输出值。它是递归的。</span>
  *
  * <img src="./img/expand.png" width="100%">
  *
- * Returns an Observable that emits items based on applying a function that you
- * supply to each item emitted by the source Observable, where that function
- * returns an Observable, and then merging those resulting Observables and
- * emitting the results of this merger. *Expand* will re-emit on the output
- * Observable every source value. Then, each output value is given to the
- * `project` function which returns an inner Observable to be merged on the
- * output Observable. Those output values resulting from the projection are also
- * given to the `project` function to produce new output values. This is how
- * *expand* behaves recursively.
+ * 返回的 Observable 基于应用一个函数来发送项，该函数提供给源 Observable 发出的每个项，
+ * 并返回一个 Observable，然后合并这些作为结果的 Observable，并发出本次合并的结果。
+ * `expand` 会重新发出在输出 Observable 上的每个源值。然后，将每个输出值传给投射函数，
+ * 该函数返回要合并到输出 Observable 上的内部 Observable 。由投影产生的那些输出值也会
+ * 被传给投射函数以产生新的输出值。这就是 `expand` 如何进行递归的。
  *
- * @example <caption>Start emitting the powers of two on every click, at most 10 of them</caption>
+ * @example <caption>每次点击开始发出的值都是乘以2的，最多连乘10次</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var powersOfTwo = clicks
  *   .mapTo(1)
@@ -45,17 +39,12 @@ export function expand<T, R>(this: Observable<T>, project: (value: T, index: num
  * @see {@link mergeMap}
  * @see {@link mergeScan}
  *
- * @param {function(value: T, index: number) => Observable} project A function
- * that, when applied to an item emitted by the source or the output Observable,
- * returns an Observable.
- * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
- * Observables being subscribed to concurrently.
- * @param {Scheduler} [scheduler=null] The IScheduler to use for subscribing to
- * each projected inner Observable.
- * @return {Observable} An Observable that emits the source values and also
- * result of applying the projection function to each value emitted on the
- * output Observable and and merging the results of the Observables obtained
- * from this transformation.
+ * @param {function(value: T, index: number) => Observable} project 函数，
+ * 当应用于源 Observable 或输出 Observable 发出的项时，返回一个 Observable 。
+ * @param {number} [concurrent=Number.POSITIVE_INFINITY] 同时订阅输入 
+ * Observables 的最大数量。
+ * @return {Observable} Observable 发出源值，同时也将投影函数应用于在输出 Observable 上
+ * 发出的每个值以得到结果，然后合并这些从转换后得到的 Observables 的结果。
  * @method expand
  * @owner Observable
  */

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -13,20 +13,18 @@ export function filter<T>(this: Observable<T>,
 /* tslint:enable:max-line-length */
 
 /**
- * Filter items emitted by the source Observable by only emitting those that
- * satisfy a specified predicate.
+ * 通过只发送源 Observable 的中满足指定 predicate 函数的项来进行过滤。
  *
- * <span class="informal">Like
- * [Array.prototype.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter),
- * it only emits a value from the source if it passes a criterion function.</span>
+ * <span class="informal">类似于
+ * [Array.prototype.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)，
+ * 它只会发出源 Observable 中符合标准函数的值。</span>
  *
  * <img src="./img/filter.png" width="100%">
  *
- * Similar to the well-known `Array.prototype.filter` method, this operator
- * takes values from the source Observable, passes them through a `predicate`
- * function and only emits those values that yielded `true`.
+ * 类似于大家所熟知的 `Array.prototype.filter` 方法，此操作符从源 Observable 中
+ * 接收值，将值传递给 `predicate` 函数并且只发出返回 `true` 的这些值。
  *
- * @example <caption>Emit only click events whose target was a DIV element</caption>
+ * @example <caption>只发出目标是 DIV 元素的点击事件</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var clicksOnDivs = clicks.filter(ev => ev.target.tagName === 'DIV');
  * clicksOnDivs.subscribe(x => console.log(x));
@@ -37,17 +35,13 @@ export function filter<T>(this: Observable<T>,
  * @see {@link ignoreElements}
  * @see {@link partition}
  * @see {@link skip}
- *
- * @param {function(value: T, index: number): boolean} predicate A function that
- * evaluates each value emitted by the source Observable. If it returns `true`,
- * the value is emitted, if `false` the value is not passed to the output
- * Observable. The `index` parameter is the number `i` for the i-th source
- * emission that has happened since the subscription, starting from the number
- * `0`.
- * @param {any} [thisArg] An optional argument to determine the value of `this`
- * in the `predicate` function.
- * @return {Observable} An Observable of values from the source that were
- * allowed by the `predicate` function.
+
+ * @param {function(value: T, index: number): boolean} predicate 评估源 Observable 
+ * 所发出的每个值的函数。如果它返回 `true`，就发出值，如果是 `false` 则不会传给输出 
+ * Observable 。`index` 参数是自订阅开始后发送序列的索引，是从 `0` 开始的。
+ * @param {any} [thisArg] 可选参数，用来决定 `predicate` 函数中的 `this` 的值。
+ * @return {Observable} 值的 Observable，这些值来自源 Observable 并且
+ * 是 `predicate` 函数所允许的。
  * @method filter
  * @owner Observable
  */

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -12,20 +12,17 @@ export function find<T>(this: Observable<T>,
 /* tslint:enable:max-line-length */
 
 /**
- * Emits only the first value emitted by the source Observable that meets some
- * condition.
+ * 只发出源 Observable 所发出的值中第一个满足条件的值。
  *
- * <span class="informal">Finds the first value that passes some test and emits
- * that.</span>
+ * <span class="informal">找到第一个通过测试的值并将其发出。</span>
  *
  * <img src="./img/find.png" width="100%">
  *
- * `find` searches for the first item in the source Observable that matches the
- * specified condition embodied by the `predicate`, and returns the first
- * occurrence in the source. Unlike {@link first}, the `predicate` is required
- * in `find`, and does not emit an error if a valid value is not found.
+ * `find` 会查找源 Observable 中与 `predicate` 函数体现的指定条件匹配的第一项，然后
+ * 将其返回。不同于 {@link first}，在 `find` 中 `predicate` 是必须的，而且如果没找到
+ * 有效的值的话也不会发出错误。
  *
- * @example <caption>Find and emit the first click that happens on a DIV element</caption>
+ * @example <caption>找到并发出第一个点击 DIV 元素的事件</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.find(ev => ev.target.tagName === 'DIV');
  * result.subscribe(x => console.log(x));
@@ -41,6 +38,10 @@ export function find<T>(this: Observable<T>,
  * in the `predicate` function.
  * @return {Observable<T>} An Observable of the first item that matches the
  * condition.
+ * @param {function(value: T, index: number, source: Observable<T>): boolean} predicate
+ * 使用每项来调用的函数，用于测试是否符合条件。
+ * @param {any} [thisArg] 可选参数，用来决定 `predicate` 函数中的 `this` 的值。
+ * @return {Observable<T>} 符合条件的第一项的 Observable 。
  * @method find
  * @owner Observable
  */

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -33,12 +33,6 @@ export function find<T>(this: Observable<T>,
  * @see {@link take}
  *
  * @param {function(value: T, index: number, source: Observable<T>): boolean} predicate
- * A function called with each item to test for condition matching.
- * @param {any} [thisArg] An optional argument to determine the value of `this`
- * in the `predicate` function.
- * @return {Observable<T>} An Observable of the first item that matches the
- * condition.
- * @param {function(value: T, index: number, source: Observable<T>): boolean} predicate
  * 使用每项来调用的函数，用于测试是否符合条件。
  * @param {any} [thisArg] 可选参数，用来决定 `predicate` 函数中的 `this` 的值。
  * @return {Observable<T>} 符合条件的第一项的 Observable 。

--- a/src/operator/findIndex.ts
+++ b/src/operator/findIndex.ts
@@ -2,21 +2,18 @@ import { Observable } from '../Observable';
 import { FindValueOperator } from './find';
 
 /**
- * Emits only the index of the first value emitted by the source Observable that
- * meets some condition.
+ * 只发出源 Observable 所发出的值中第一个满足条件的值的索引。
  *
- * <span class="informal">It's like {@link find}, but emits the index of the
- * found value, not the value itself.</span>
+ * <span class="informal">它很像 {@link find} , 但发出的是找到的值的索引，
+ * 而不是值本身。</span>
  *
  * <img src="./img/findIndex.png" width="100%">
  *
- * `findIndex` searches for the first item in the source Observable that matches
- * the specified condition embodied by the `predicate`, and returns the
- * (zero-based) index of the first occurrence in the source. Unlike
- * {@link first}, the `predicate` is required in `findIndex`, and does not emit
- * an error if a valid value is not found.
+ * `findIndex` 会查找源 Observable 中与 `predicate` 函数体现的指定条件匹配的第一项，然后
+ * 返回其索引(从0开始)。不同于 {@link first}，在 `findIndex` 中 `predicate` 是必须的，而且如果没找到
+ * 有效的值的话也不会发出错误。
  *
- * @example <caption>Emit the index of first click that happens on a DIV element</caption>
+ * @example <caption>找到并发出第一个点击 DIV 元素的事件的索引</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.findIndex(ev => ev.target.tagName === 'DIV');
  * result.subscribe(x => console.log(x));
@@ -27,11 +24,9 @@ import { FindValueOperator } from './find';
  * @see {@link take}
  *
  * @param {function(value: T, index: number, source: Observable<T>): boolean} predicate
- * A function called with each item to test for condition matching.
- * @param {any} [thisArg] An optional argument to determine the value of `this`
- * in the `predicate` function.
- * @return {Observable} An Observable of the index of the first item that
- * matches the condition.
+ * 使用每项来调用的函数，用于测试是否符合条件。
+ * @param {any} [thisArg] 可选参数，用来决定 `predicate` 函数中的 `this` 的值。
+ * @return {Observable<T>} 符合条件的第一项的索引的 Observable 。
  * @method find
  * @owner Observable
  */

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -25,28 +25,24 @@ export function first<T>(this: Observable<T>,
                          defaultValue?: T): Observable<T>;
 
 /**
- * Emits only the first value (or the first value that meets some condition)
- * emitted by the source Observable.
+ * 只发出由源 Observable 所发出的值中第一个(或第一个满足条件的值)。
  *
- * <span class="informal">Emits only the first value. Or emits only the first
- * value that passes some test.</span>
+ * <span class="informal">只发出第一个值。或者只发出第一个通过测试的值。</span>
  *
  * <img src="./img/first.png" width="100%">
  *
- * If called with no arguments, `first` emits the first value of the source
- * Observable, then completes. If called with a `predicate` function, `first`
- * emits the first value of the source that matches the specified condition. It
- * may also take a `resultSelector` function to produce the output value from
- * the input value, and a `defaultValue` to emit in case the source completes
- * before it is able to emit a valid value. Throws an error if `defaultValue`
- * was not provided and a matching element is not found.
+ * 如果不使用参数调用，`first` 会发出源 Observable 中的第一个值，然后完成。如果使用
+ * `predicate` 函数来调用，`first` 会发出源 Observable 第一个满足条件的值。它还可以
+ * 接收 `resultSelector` 函数根据输入值生成输出值，假如在源 Observable 完成前无法发
+ * 处一个有效值的话，那么会发出 `defaultValue` 。如果没有提供 `defaultValue` 并且也
+ * 找不到匹配的元素，则抛出错误。
  *
- * @example <caption>Emit only the first click that happens on the DOM</caption>
+ * @example <caption>只发出第一次点击 DOM 的事件</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.first();
  * result.subscribe(x => console.log(x));
  *
- * @example <caption>Emits the first click that happens on a DIV</caption>
+ * @example <caption>只发出第一次点击 DIV 元素的事件</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.first(ev => ev.target.tagName === 'DIV');
  * result.subscribe(x => console.log(x));
@@ -55,21 +51,18 @@ export function first<T>(this: Observable<T>,
  * @see {@link find}
  * @see {@link take}
  *
- * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
- * callback if the Observable completes before any `next` notification was sent.
+ * @throws {EmptyError} 如果在 Observable 完成之前还没有发出任何 `next` 通知的话，
+ * 就把 EmptyError 发送给观察者的 `error` 回调函数。
  *
  * @param {function(value: T, index: number, source: Observable<T>): boolean} [predicate]
- * An optional function called with each item to test for condition matching.
- * @param {function(value: T, index: number): R} [resultSelector] A function to
- * produce the value on the output Observable based on the values
- * and the indices of the source Observable. The arguments passed to this
- * function are:
- * - `value`: the value that was emitted on the source.
- * - `index`: the "index" of the value from the source.
- * @param {R} [defaultValue] The default value emitted in case no valid value
- * was found on the source.
- * @return {Observable<T|R>} An Observable of the first item that matches the
- * condition.
+ * 使用每项来调用的可选函数，用于测试是否符合条件。
+ * @param {function(value: T, index: number): R} [resultSelector] 函数，它基于源 
+ * Observable 的值和索引来生成输出 Observable 的值。传给这个函数的参数有：
+ * - `value`: 在源 Observable 上发出的值。
+ * - `index`: 源值的索引。
+ * @param {R} [defaultValue] 假如在源 Observable 上没有找到有效值，就会发出这个
+ * 默认值。
+ * @return {Observable<T|R>} 符合条件的第一项的 Observable 。
  * @method first
  * @owner Observable
  */

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -34,7 +34,7 @@ export function first<T>(this: Observable<T>,
  * 如果不使用参数调用，`first` 会发出源 Observable 中的第一个值，然后完成。如果使用
  * `predicate` 函数来调用，`first` 会发出源 Observable 第一个满足条件的值。它还可以
  * 接收 `resultSelector` 函数根据输入值生成输出值，假如在源 Observable 完成前无法发
- * 处一个有效值的话，那么会发出 `defaultValue` 。如果没有提供 `defaultValue` 并且也
+ * 出一个有效值的话，那么会发出 `defaultValue` 。如果没有提供 `defaultValue` 并且也
  * 找不到匹配的元素，则抛出错误。
  *
  * @example <caption>只发出第一次点击 DOM 的事件</caption>

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -14,13 +14,12 @@ export function groupBy<T, K, R>(this: Observable<T>, keySelector: (value: T) =>
 /* tslint:enable:max-line-length */
 
 /**
- * Groups the items emitted by an Observable according to a specified criterion,
- * and emits these grouped items as `GroupedObservables`, one
- * {@link GroupedObservable} per group.
+ * 根据指定条件将源 Observable 发出的值进行分组，并将这些分组作为 `GroupedObservables` 
+ * 发出，每一个分组都是一个 {@link GroupedObservable} 。
  *
  * <img src="./img/groupBy.png" width="100%">
  *
- * @example <caption>Group objects by id and return as array</caption>
+ * @example <caption>通过 id 分组并返回数组</caption>
  * Observable.of<Obj>({id: 1, name: 'aze1'},
  *                    {id: 2, name: 'sf2'},
  *                    {id: 2, name: 'dg2'},
@@ -34,7 +33,7 @@ export function groupBy<T, K, R>(this: Observable<T>, keySelector: (value: T) =>
  *     .flatMap( (group$) => group$.reduce((acc, cur) => [...acc, cur], []))
  *     .subscribe(p => console.log(p));
  *
- * // displays:
+ * // 显示：
  * // [ { id: 1, name: 'aze1' },
  * //   { id: 1, name: 'erg1' },
  * //   { id: 1, name: 'df1' } ]
@@ -46,7 +45,7 @@ export function groupBy<T, K, R>(this: Observable<T>, keySelector: (value: T) =>
  * //
  * // [ { id: 3, name: 'qfs3' } ]
  *
- * @example <caption>Pivot data on the id field</caption>
+ * @example <caption>以 id 字段为主组装数据</caption>
  * Observable.of<Obj>({id: 1, name: 'aze1'},
  *                    {id: 2, name: 'sf2'},
  *                    {id: 2, name: 'dg2'},
@@ -56,27 +55,26 @@ export function groupBy<T, K, R>(this: Observable<T>, keySelector: (value: T) =>
  *                    {id: 3, name: 'qfs1'},
  *                    {id: 2, name: 'qsgqsfg2'}
  *                   )
- *     .groupBy(p => p.id, p => p.anme)
+ *     .groupBy(p => p.id, p => p.name)
  *     .flatMap( (group$) => group$.reduce((acc, cur) => [...acc, cur], ["" + group$.key]))
  *     .map(arr => ({'id': parseInt(arr[0]), 'values': arr.slice(1)}))
  *     .subscribe(p => console.log(p));
  *
- * // displays:
+ * // 显示：
  * // { id: 1, values: [ 'aze1', 'erg1', 'df1' ] }
  * // { id: 2, values: [ 'sf2', 'dg2', 'sfqfb2', 'qsgqsfg2' ] }
  * // { id: 3, values: [ 'qfs1' ] }
  *
- * @param {function(value: T): K} keySelector A function that extracts the key
- * for each item.
- * @param {function(value: T): R} [elementSelector] A function that extracts the
- * return element for each item.
+ * @param {function(value: T): K} keySelector 提取每项的键的函数。
+ * @param {function(value: T): R} [elementSelector] 提取每项返回元素的函数。
  * @param {function(grouped: GroupedObservable<K,R>): Observable<any>} [durationSelector]
- * A function that returns an Observable to determine how long each group should
- * exist.
+ * 返回一个 Observable 来确定每个组应该存在多长时间的函数。
  * @return {Observable<GroupedObservable<K,R>>} An Observable that emits
  * GroupedObservables, each of which corresponds to a unique key value and each
  * of which emits those items from the source Observable that share that key
  * value.
+ * @return {Observable<GroupedObservable<K,R>>} 发出 GroupedObservables 的 Observable，
+ * 每个 GroupedObservable 对应唯一的键值，并且会发出源 Observable 中共享该键值的项。
  * @method groupBy
  * @owner Observable
  */
@@ -252,10 +250,8 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
 }
 
 /**
- * An Observable representing values belonging to the same group represented by
- * a common key. The values emitted by a GroupedObservable come from the source
- * Observable. The common key is available as the field `key` on a
- * GroupedObservable instance.
+ * 该 Observable 表示因具有共同的键而属于同一个组的值 。由 GroupedObservable 发出的值
+ * 来自于源 Observable 。共同的键可作为 GroupedObservable 实例上的 `key` 字段。
  *
  * @class GroupedObservable<K, T>
  */

--- a/src/operator/ignoreElements.ts
+++ b/src/operator/ignoreElements.ts
@@ -4,12 +4,12 @@ import { Subscriber } from '../Subscriber';
 import { noop } from '../util/noop';
 
 /**
- * Ignores all items emitted by the source Observable and only passes calls of `complete` or `error`.
+ * 忽略源 Observable 所发送的所有项，只传递 `complete` 或 `error` 的调用。
  *
  * <img src="./img/ignoreElements.png" width="100%">
  *
- * @return {Observable} An empty Observable that only calls `complete`
- * or `error`, based on which one is called by the source Observable.
+ * @return {Observable} 该 Observable 是空的，只调用 `complete` 或 
+ * `error`，调用是基于源 Observable 的调用。
  * @method ignoreElements
  * @owner Observable
  */

--- a/src/operator/isEmpty.ts
+++ b/src/operator/isEmpty.ts
@@ -3,11 +3,11 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 
 /**
- * If the source Observable is empty it returns an Observable that emits true, otherwise it emits false.
+ * 如果源 Observable 是空的话，它返回一个发出 true 的 Observable，否则发出 false 。
  *
  * <img src="./img/isEmpty.png" width="100%">
  *
- * @return {Observable} An Observable that emits a Boolean.
+ * @return {Observable} 发出布尔值的 Observable 。
  * @method isEmpty
  * @owner Observable
  */

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -26,19 +26,18 @@ export function last<T>(this: Observable<T>,
 /* tslint:enable:max-line-length */
 
 /**
- * Returns an Observable that emits only the last item emitted by the source Observable.
- * It optionally takes a predicate function as a parameter, in which case, rather than emitting
- * the last item from the source Observable, the resulting Observable will emit the last item
- * from the source Observable that satisfies the predicate.
+ * 返回的 Observable 只发出由源 Observable 发出的最后一个值。它可以接收一个可选的 predicate 函数作为
+ * 参数，如果传入 predicate 的话则发送的不是源 Observable 的最后一项，而是发出源 Observable 中
+ * 满足 predicate 函数的最后一项。
  *
  * <img src="./img/last.png" width="100%">
  *
- * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
- * callback if the Observable completes before any `next` notification was sent.
- * @param {function} predicate - The condition any source emitted item has to satisfy.
- * @return {Observable} An Observable that emits only the last item satisfying the given condition
- * from the source, or an NoSuchElementException if no such items are emitted.
- * @throws - Throws if no items that match the predicate are emitted by the source Observable.
+ * @throws {EmptyError} 如果 Observale 完成前还没有发出任何 `next` 通知的话，就会
+ * 发送 EmptyError 给观察者的 `error` 回调函数。
+ * @param {function} predicate - 任何由源 Observable 发出的项都必须满足的条件函数。
+ * @return {Observable} 该 Observable 只发出源 Observable 中满足给定条件的最后一项，
+ * 或者没有任何项满足条件时发出 NoSuchElementException 。
+ * @throws - 如果在源 Observable 中没有匹配 predicate 函数的项，则抛出。
  * @method last
  * @owner Observable
  */

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -3,20 +3,18 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 
 /**
- * Applies a given `project` function to each value emitted by the source
- * Observable, and emits the resulting values as an Observable.
+ * 将给定的 `project` 函数应用于源 Observable 发出的每个值，并将结果值作为 
+ * Observable 发出。
  *
- * <span class="informal">Like [Array.prototype.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map),
- * it passes each source value through a transformation function to get
- * corresponding output values.</span>
+ * <span class="informal">类似于 [Array.prototype.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)，
+ * 它把每个源值传递给转化函数以获得相应的输出值。</span>
  *
  * <img src="./img/map.png" width="100%">
  *
- * Similar to the well known `Array.prototype.map` function, this operator
- * applies a projection to each value and emits that projection in the output
- * Observable.
+ * 类似于大家所熟知的 `Array.prototype.map` 方法，此操作符将投射函数应用于每个值
+ * 并且在输出 Observable 中发出投射后的结果。
  *
- * @example <caption>Map every click to the clientX position of that click</caption>
+ * @example <caption>将每次点击映射为这次点击的 clientX </caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var positions = clicks.map(ev => ev.clientX);
  * positions.subscribe(x => console.log(x));
@@ -24,14 +22,11 @@ import { Observable } from '../Observable';
  * @see {@link mapTo}
  * @see {@link pluck}
  *
- * @param {function(value: T, index: number): R} project The function to apply
- * to each `value` emitted by the source Observable. The `index` parameter is
- * the number `i` for the i-th emission that has happened since the
- * subscription, starting from the number `0`.
- * @param {any} [thisArg] An optional argument to define what `this` is in the
- * `project` function.
- * @return {Observable<R>} An Observable that emits the values from the source
- * Observable transformed by the given `project` function.
+ * @param {function(value: T, index: number): R} project 应用于由源 Observable 
+ * 所发出的每个值的函数。`index` 参数是自订阅开始后发送序列的索引，是从 `0` 开始的。
+ * @param {any} [thisArg] 可选参数，定义在 `project` 函数中的 `this` 是什么。
+ * @return {Observable<R>} 该 Observable 发出源 Observable 中经过给定的 `project` 
+ * 函数转换的值。
  * @method map
  * @owner Observable
  */

--- a/src/operator/mapTo.ts
+++ b/src/operator/mapTo.ts
@@ -3,28 +3,25 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 
 /**
- * Emits the given constant value on the output Observable every time the source
- * Observable emits a value.
+ * 每次源 Observble 发出值时，都在输出 Observable 上发出给定的常量值。
  *
- * <span class="informal">Like {@link map}, but it maps every source value to
- * the same output value every time.</span>
+ * <span class="informal">类似于 {@link map}，但它每一次都把源值映射成同一个输出值。</span>
  *
  * <img src="./img/mapTo.png" width="100%">
  *
- * Takes a constant `value` as argument, and emits that whenever the source
- * Observable emits a value. In other words, ignores the actual source value,
- * and simply uses the emission moment to know when to emit the given `value`.
+ * 接收常量 `value` 作为参数，并每当源 Observable 发出值时都发出这个值。换句话说，
+ * 就是忽略实际的源值，然后简单地使用这个发送时间点以知道何时发出给定的 `value` 。
  *
- * @example <caption>Map every click to the string 'Hi'</caption>
+ * @example <caption>把每次点击映射成字符串 'Hi'</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var greetings = clicks.mapTo('Hi');
  * greetings.subscribe(x => console.log(x));
  *
  * @see {@link map}
  *
- * @param {any} value The value to map each source value to.
- * @return {Observable} An Observable that emits the given `value` every time
- * the source Observable emits something.
+ * @param {any} value 将每个源值映射成的值。
+ * @return {Observable} 该 Observable 在每次源 Observable 发出值的时候发出给定
+ * 的 `value` 。
  * @method mapTo
  * @owner Observable
  */


### PR DESCRIPTION
完成下列操作符的 API 翻译：
  - [x] elementAt
  - [x] every
  - [x] exhaust
  - [x] exhaustMap
  - [x] expand
  - [x] filter
  - [x] find
  - [x] findIndex
  - [x] first
  - [x] groupBy
  - [x] ignoreElements
  - [x] isEmpty
  - [x] last
  - [x] isEmpty
  - [x] map
  - [x] mapTo