### PR TITLE
docs(observer): fix a typo

### DIFF
--- a/doc/observer.md
+++ b/doc/observer.md
@@ -37,7 +37,7 @@ var observer = {
 observable.subscribe(x => console.log('Observer got a next value: ' + x));
 ```
 
-在 `observable.subscribe` 内部，它回创建一个观察者对象并使用第一个回调函数参数作为 `next` 的处理方法。所有三种类型的回调函数都可以直接作为参数来提供：
+在 `observable.subscribe` 内部，它会创建一个观察者对象并使用第一个回调函数参数作为 `next` 的处理方法。所有三种类型的回调函数都可以直接作为参数来提供：
 
 <!-- skip-example -->
 ```js


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
